### PR TITLE
add custom domain UI and timestamp with custom domain for static site generator

### DIFF
--- a/wordproof-timestamp/WordProofTimestampFree.php
+++ b/wordproof-timestamp/WordProofTimestampFree.php
@@ -64,8 +64,20 @@ class WordProofTimestampFree
   {
     global $post;
     if ($column_name == 'wordproof') {
-      
-      $meta = PostMetaHelper::getPostMeta($post, ['wordproof_date']); //TODO: HEY WELCOME BACK. ADD 'date
+
+      // for >= v0.6
+      $meta = PostMetaHelper::getPostMeta($post, ['date']);
+      if (isset($meta->date)) {
+        if ($meta->date === get_the_modified_date('c', $post->ID)) {
+          echo '<a target="_blank" href="' . get_permalink($post->ID) . '#wordproof">Stamped</a>';
+        } else {
+          echo '<a target="_blank" href="' . get_permalink($post->ID) . '#wordproof">Outdated</a>';
+        }
+        return;
+      }
+
+      // for < 0.6
+      $meta = PostMetaHelper::getPostMeta($post, ['wordproof_date']);
       if (isset($meta->wordproof_date)) {
         if ($meta->wordproof_date === get_the_modified_date('Y-m-d H:i:s', $post->ID)) {
           echo '<a target="_blank" href="' . get_permalink($post->ID) . '#wordproof">Stamped</a>';
@@ -75,7 +87,6 @@ class WordProofTimestampFree
       } else {
         echo '—';
       }
-
     }
   }
 

--- a/wordproof-timestamp/WordProofTimestampFree.php
+++ b/wordproof-timestamp/WordProofTimestampFree.php
@@ -4,6 +4,7 @@ namespace WordProofTimestampFree;
 
 use WordProofTimestampFree\includes\AnalyticsHelper;
 use WordProofTimestampFree\includes\ChainHelper;
+use WordProofTimestampFree\includes\DomainHelper;
 use WordProofTimestampFree\includes\MetaBox;
 use WordProofTimestampFree\includes\NotificationHelper;
 use WordProofTimestampFree\includes\Page\SettingsPage;
@@ -12,6 +13,7 @@ use WordProofTimestampFree\includes\CertificateHelper;
 use WordProofTimestampFree\includes\PostMetaHelper;
 use WordProofTimestampFree\includes\TimestampAjaxHelper;
 use WordProofTimestampFree\includes\Controller\SchemaController;
+
 
 /**
  * Class WordProofTimestampFree
@@ -130,7 +132,7 @@ class WordProofTimestampFree
       'settingsURL' => admin_url('admin.php?page=wordproof'),
       'ajaxSecurity' => wp_create_nonce('wordproof'),
       'postId' => (!empty($post->ID)) ? $post->ID : false,
-      'permalink' => (!empty($post->ID)) ? get_permalink($post) : false,
+      'permalink' => DomainHelper::getPermalinkOrCustomDomain($post),
       'network' => get_option('wordproof_network', false),
       'accountName' => get_option('wordproof_accountname', ''),
       'wordBalance' => get_option('wordproof_balance', 0),

--- a/wordproof-timestamp/includes/CertificateHelper.php
+++ b/wordproof-timestamp/includes/CertificateHelper.php
@@ -17,6 +17,11 @@ class CertificateHelper {
         return $text;
     }
 
+    public static function getCustomDomainText() {
+        $text = get_option('wordproof_custom_domain', null) ?: self::$default_url;
+        return $text;
+    }
+
     public static function getCertificateUrl() {
         $url = self::$default_url;
         return $url;

--- a/wordproof-timestamp/includes/Controller/HashController.php
+++ b/wordproof-timestamp/includes/Controller/HashController.php
@@ -83,9 +83,13 @@ class HashController
     $array['type'] = WEB_ARTICLE_TIMESTAMP;
     $array['version'] = CURRENT_WEB_ARTICLE_TIMESTAMP_VERSION;
     $array['title'] = $post->post_title;
-    $array['content'] = $post->post_content;
+    $custom_domain = DomainHelper::getCustomDomain();
+    if ($custom_domain) {
+      $array['content'] = DomainHelper::replaceDomainInContent($post->post_content, $custom_domain);
+    } else {
+      $array['content'] = $post->post_content;
+    }
     $array['date'] = get_the_modified_date('c', $post);
-    $array['wordproof_date'] = get_the_modified_date('Y-m-d H:i:s', $post);
     return $array;
   }
 

--- a/wordproof-timestamp/includes/Controller/HashController.php
+++ b/wordproof-timestamp/includes/Controller/HashController.php
@@ -3,6 +3,7 @@
 namespace WordProofTimestampFree\includes\Controller;
 
 use WordProofTimestampFree\includes\PostMetaHelper;
+use WordProofTimestampFree\includes\DomainHelper;
 
 class HashController
 {
@@ -84,6 +85,7 @@ class HashController
     $array['title'] = $post->post_title;
     $array['content'] = $post->post_content;
     $array['date'] = get_the_modified_date('c', $post);
+    $array['wordproof_date'] = get_the_modified_date('Y-m-d H:i:s', $post);
     return $array;
   }
 
@@ -96,7 +98,7 @@ class HashController
   {
     $array = [];
     //TODO: Get selected attributes
-    $array['url'] = get_permalink($post);
+    $array['url'] = DomainHelper::getPermalinkOrCustomDomain($post);
     $array = apply_filters('wordproof_hash_attributes', $array);
     return $array;
   }

--- a/wordproof-timestamp/includes/DomainHelper.php
+++ b/wordproof-timestamp/includes/DomainHelper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WordProofTimestampFree\includes;
+
+class DomainHelper
+{
+  public static function getPermalinkOrCustomDomain($post) {
+    $custom_domain = get_option('wordproof_custom_domain');
+    $permalink = (!empty($post->ID)) ? get_permalink($post->ID) : false;
+
+    if ($custom_domain && $permalink) {
+      $url = parse_url($permalink);
+      $ret = $custom_domain . $url['path'];
+      return $ret;
+    }
+
+    if ($custom_domain) {
+      return $custom_domain;
+    }
+    return $permalink;
+  }
+}

--- a/wordproof-timestamp/includes/DomainHelper.php
+++ b/wordproof-timestamp/includes/DomainHelper.php
@@ -19,4 +19,25 @@ class DomainHelper
     }
     return $permalink;
   }
+
+  public static function getCustomDomain() {
+    $custom_domain = get_option('wordproof_custom_domain');
+    return $custom_domain; 
+  }
+
+  public static function replaceDomainInContent($content, $domain) {
+    $url = get_site_url();
+    $parsed_url = parse_url($url);
+    $host = $parsed_url['host'];
+    $port = $parsed_url['port'];
+
+    $host_with_port = '';
+    if ($port) {
+      $host_with_port = "${host}:${port}";
+    } else {
+      $host_with_port = "${host}";
+    }
+
+    return str_replace($host_with_port, $domain, $content);
+  }
 }

--- a/wordproof-timestamp/includes/Page/SettingsPage.php
+++ b/wordproof-timestamp/includes/Page/SettingsPage.php
@@ -12,7 +12,7 @@ class SettingsPage {
 
     public function __construct() {
         add_action('admin_menu', array($this, 'addSettingsPage'));
-	    add_action('admin_post_wordproof_form_action', array($this, 'saveSettings'));
+	      add_action('admin_post_wordproof_form_action', array($this, 'saveSettings'));
     }
 
     public function addSettingsPage() {
@@ -30,6 +30,7 @@ class SettingsPage {
         wp_localize_script('wordproof.admin.js', 'wordproofSettings', [
             'network' => get_option('wordproof_network', false),
             'certificateText' => CertificateHelper::getCertificateText(),
+            'customDomainText' => CertificateHelper::getCustomDomainText(),
             'saveChanges' => __('Save Changes')
         ]);
 
@@ -55,6 +56,10 @@ class SettingsPage {
         if (isset($_POST['wordproof_certificate_text'])) {
           $value = sanitize_text_field($_POST['wordproof_certificate_text']);
           update_option('wordproof_certificate_text', $value);
+        }
+        if (isset($_POST['wordproof_custom_domain'])) {
+          $value = sanitize_text_field($_POST['wordproof_custom_domain']);
+          update_option('wordproof_custom_domain', $value);
         }
       }
       wp_redirect(admin_url('admin.php?page=wordproof'));

--- a/wordproof-timestamp/src/js/components/Tabs/Customize/Customize.js
+++ b/wordproof-timestamp/src/js/components/Tabs/Customize/Customize.js
@@ -4,8 +4,15 @@ export default class Customize extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      certificateText: wordproofSettings.certificateText
+      certificateText: wordproofSettings.certificateText,
+      customDomainText: wordproofSettings.customDomainText,
+      isToggleOn: false
     }
+    this.handleCustomDomainToggle = this.handleCustomDomainToggle.bind(this)
+  }
+
+  handleCustomDomainToggle() {
+    this.setState({isToggleOn: !this.state.isToggleOn})
   }
 
   render() {
@@ -22,9 +29,20 @@ export default class Customize extends Component {
                    value={this.state.certificateText}
                    onChange={e => this.setState({certificateText: e.target.value})}/>
           </div>
+          <a className="collapsible" onClick={this.handleCustomDomainToggle}>Show advanced settings...</a>
+          <div className="form-group">
+            <div className={ this.state.isToggleOn ? '' : 'hidden' }>
+              <label htmlFor="" className="label"
+                    title="Replace URLs in the BlockChain Certificate permalink.">Replace URLs in the BlockChain Certificate permalink</label>
+              <p>In some steps, the URL in the blockchain certificate does not match the URL of the website. You can enter a custom domain below which will be visible in the BlockChain Certificate pop-up. Do not add &#39;/&#39; at the end of your custom URL.</p>
+              <input type="text" className="textinput" name="wordproof_custom_domain"
+                  value={this.state.customDomainText}
+                  onChange={e => this.setState({customDomainText: e.target.value})}/>
+            </div>
+          </div>
+          <p />
           <input type="submit" name="submit" id="submit" className="button is-primary"
                  value={wordproofSettings.saveChanges}/>
-
         </div>
       </div>
     )


### PR DESCRIPTION
## Description
This PR adds a feature that user timestamp their post with custom domain.

Related topic on wordpress forum.
https://wordpress.org/support/topic/setting-custom-domainor-name-alternative-hostname/

## Type of change
- [-] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [-] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [-] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Testing static site generator. (I used [Shifter](https://www.getshifter.io/) )

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
- [-] New and existing unit tests pass locally with my changes
- [-] Any dependent changes have been merged and published in downstream modules

