### PR TITLE
Changed saveTimestamp() to return instead of exit

### DIFF
--- a/includes/AutomaticHelper.php
+++ b/includes/AutomaticHelper.php
@@ -192,8 +192,7 @@ class AutomaticHelper
                     OptionsHelper::set('balance', 0);
                 }
 
-                TimestampController::saveTimestamp($this->post->ID, '', '', true);
-                break;
+                return TimestampController::saveTimestamp($this->post->ID, '', '', true);
             case 'retry_webhook':
             case 'validate_token':
             case 'get_articles':

--- a/includes/Controller/TimestampController.php
+++ b/includes/Controller/TimestampController.php
@@ -14,7 +14,6 @@ class TimestampController {
 	}
 
 	public static function saveTimestamp( $postId, $chain, $transactionId, $remote = false ) {
-
 		$metaFields = HashController::getFields( $postId );
 
 		$meta               = $metaFields['properties'];
@@ -26,13 +25,12 @@ class TimestampController {
 
 		PostMetaHelper::savePostMeta( $postId, $meta, $remote );
 
-		echo json_encode( array(
+		return array(
 			'success' => true,
 			'data'    => array(
 				'url' => DomainHelper::getPermalink( $postId ) . '#wordproof'
 			),
-		) );
-		exit;
+		);
 	}
 
 	public function saveTimestampAjax() {
@@ -45,14 +43,7 @@ class TimestampController {
 		$chain         = OptionsHelper::get('network');
 		$transactionId = sanitize_text_field( wp_unslash( ($_REQUEST['transaction_id']) ? $_REQUEST['transaction_id'] : '' ) );
 
-		self::saveTimestamp( $postId, $chain, $transactionId );
-
-		echo json_encode( array(
-			'success' => true,
-			'data'    => array(
-				'url' => DomainHelper::getPermalink( $postId ) . '#wordproof'
-			),
-		) );
+		echo json_encode( self::saveTimestamp( $postId, $chain, $transactionId ) );
 		exit;
 	}
 


### PR DESCRIPTION
Hi all,

The `saveTimestamp()` method in `TimestampController.php` was echoing and exiting at the end of the method, but this method is also used in Cron jobs.

On some of our clients' WordPress website we have WordProof implemented and on every post save a call is made to WordProof through a Cron job. The problem is that when the queue is run (`wp cron event run --due-now`) and it contains multiple items, it will stop the execution after a WordProof item is processed, because of the `exit;` at the end of the method.

This PR changes that functionality and returns the result instead of exiting. I also modified other methods that call this method, so this should not break any other functionality.

Hope this is helpful and according to your standards! If you have any questions or doubts, don't hesitate to let me know.